### PR TITLE
fix the memory leaks

### DIFF
--- a/kernel/lib/sysparam/sysparam.c
+++ b/kernel/lib/sysparam/sysparam.c
@@ -499,7 +499,7 @@ static ssize_t hexstr_to_val(const char *str, uint8_t **buf)
         uint8_t c = str[pos];
 
         if (!isxdigit(c)) {
-        	free(hexbuffer);
+            free(hexbuffer);
             return ERR_NOT_VALID;
         }
 

--- a/kernel/lib/sysparam/sysparam.c
+++ b/kernel/lib/sysparam/sysparam.c
@@ -499,6 +499,7 @@ static ssize_t hexstr_to_val(const char *str, uint8_t **buf)
         uint8_t c = str[pos];
 
         if (!isxdigit(c)) {
+        	free(hexbuffer);
             return ERR_NOT_VALID;
         }
 

--- a/system/udev/intel-ethernet/ethernet.c
+++ b/system/udev/intel-ethernet/ethernet.c
@@ -165,6 +165,7 @@ static mx_status_t eth_bind(mx_driver_t* drv, mx_device_t* dev) {
 
     mx_status_t r;
     if ((r = pci->claim_device(dev)) < 0) {
+        free(edev);
         return r;
     }
 


### PR DESCRIPTION
On line no. 502 of '[sysparam.c](https://github.com/bryongloden/magenta-1/blob/master/kernel/lib/sysparam/sysparam.c#L502)' there is a memory leak and on line no. 168 of '[ethernet.c](https://github.com/bryongloden/magenta-1/blob/master/system/udev/intel-ethernet/ethernet.c#L168)' there is memory leak -- both memory leaks are errors.

Found by https://github.com/bryongloden/cppcheck
